### PR TITLE
Add ExecReload to the unit, use it in the resume script

### DIFF
--- a/amdgpu-clocks-resume
+++ b/amdgpu-clocks-resume
@@ -2,6 +2,6 @@
 
 case $1 in
   post)
-    /usr/bin/systemctl restart amdgpu-clocks
+    /usr/bin/systemctl reload amdgpu-clocks
     ;;
 esac

--- a/amdgpu-clocks.service
+++ b/amdgpu-clocks.service
@@ -7,7 +7,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/bin/amdgpu-clocks
 ExecStop=/usr/local/bin/amdgpu-clocks restore
+ExecReload=/usr/local/bin/amdgpu-clocks
 StandardOutput=syslog
 
 [Install]
-WantedBy=multi-user.target sleep.target suspend.target hibernate.target
+WantedBy=multi-user.target


### PR DESCRIPTION
`systemctl restart` is the same as `systemctl stop && systemctl start`.
Thus, after a resume from suspend, the script will first restore the
default settings and then apply them again, which is useless as suspend
already does that.

Instead, we use `ExecReload` that will simply call the script once with
`systemctl reload` to just reapply the new settings.