### PR TITLE
Do not reload after suspend if unit isn't started

### DIFF
--- a/amdgpu-clocks-resume
+++ b/amdgpu-clocks-resume
@@ -2,6 +2,8 @@
 
 case $1 in
   post)
-    /usr/bin/systemctl reload amdgpu-clocks
+    if $(systemctl is-active --quiet amdgpu-clocks.service); then
+        /usr/bin/systemctl reload amdgpu-clocks
+    fi
     ;;
 esac


### PR DESCRIPTION
If the unit wasn't started before suspend, `systemctl reload` will not
work, and it would be unwanted anyway.