### PR TITLE
Update StandardOutput option in systemd service file

### DIFF
--- a/amdgpu-clocks.service
+++ b/amdgpu-clocks.service
@@ -8,7 +8,6 @@ RemainAfterExit=yes
 ExecStart=/usr/local/bin/amdgpu-clocks
 ExecStop=/usr/local/bin/amdgpu-clocks restore
 ExecReload=/usr/local/bin/amdgpu-clocks
-StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Update service file based on suggestion from systemd.

Systemd version:
```
$ systemctl --version
systemd 246 (246.6-1-arch)
```
Systemd log output
```
$ sudo systemctl status amdgpu-clocks
● amdgpu-clocks.service - Set custom amdgpu clocks & voltages
     Loaded: loaded (/usr/lib/systemd/system/amdgpu-clocks.service; enabled; vendor preset: disabled)
     Active: inactive (dead)

Oct 24 22:00:38 systemd[1]: /usr/lib/systemd/system/amdgpu-clocks.service:11: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
```