### PR TITLE
amdgpu-clocks: use /usr/bin/env bash shebang

### DIFF
--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 USER_STATES_PATH=${USER_STATES_PATH:-/etc/default/amdgpu-custom-state}
 SYS_PPFMASK=/sys/module/amdgpu/parameters/ppfeaturemask


### PR DESCRIPTION
This way it is more portable and will make this script be able to start on NixOS