### PR TITLE
Updated RDNA 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,22 +139,36 @@ and specify custom power states in `/etc/default/amdgpu-custom-states.card0`:
 ```shell
 $ sudo amdgpu-clocks
 
-Detecting the state values at /sys/class/drm/card0/device/pp_od_clk_voltage:
-    SCLK state 0: 700Mhz
-    SCLK state 1: 2539Mhz
-    MCLK state 0: 97Mhz
-    MCLK state 1: 1000MHz
-    VDD GFX Offset: 0mV
-    Maximum clocks & voltages:
-    SCLK clock 3150Mhz
-    MCLK clock 1200Mhz
-    Curent power cap: 130W
-Verifying user state values at /etc/default/amdgpu-custom-state.card0:
-    VDD GFX Offset: -75mV
-    Force performance level to manual
-    Force power cap to 99W
-Committing custom states to /sys/class/drm/card0/device/pp_od_clk_voltage:
-    Done
+Detecting the state values at /sys/class/drm/card1/device/pp_od_clk_voltage:
+  SCLK offset: 0Mhz
+  MCLK state 0: 97Mhz
+  MCLK state 1: 1259MHz
+  VDD GFX Offset: 0mV
+  Value ranges:
+    SCLK offset range:    -500Mhz       1000Mhz
+    MCLK clock range:      97Mhz       1500Mhz
+    VDDGFX offset range:    -200mv          0mv
+  Curent power cap: 304W
+
+Detecting the state values at /sys/class/drm/card1/device/gpu_od/fan_ctrl/fan_zero_rpm_enable:
+  Zero RPM enable: 1
+  Value ranges:
+    Zero RPM enable range: 0 1
+
+Detecting the state values at /sys/class/drm/card1/device/gpu_od/fan_ctrl/fan_zero_rpm_stop_temperature:
+  Zero RPM temperature: 50
+  Value ranges:
+    Zero RPM stop temperature range: 50 110
+
+Verifying user state values at /etc/default/amdgpu-custom-state.card1:
+  SCLK offset: 100MHz
+  VDD GFX Offset: -75mV
+  Force power cap to 250W
+  Zero RPM enable: 0
+  Zero RPM temperature: 65
+
+Committing custom states to /sys/class/drm/card1/device/pp_od_clk_voltage:
+  Done
 ```
 
 The script can also be invoked with specific custom state file prefix (can be

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ FORCE_POWER_CAP: 99000000
 ```
 
 ### RDNA 4
-With **RDNA 4**, `pp_od_clk_voltage` exposes two `SCLK` offsets but only `1`
-(max `SCLK` offset) can be adjusted. Example of custom power state file:
+With **RDNA4**, `pp_od_clk_voltage` exposes `SCLK_OFFSET` instead of multiple
+`SCLK` states. Example of custom power state file:
 ```shell
 OD_SCLK_OFFSET:
-1: 200Mhz
+200Mhz
 OD_MCLK:
 0: 97MHz
 1: 2519MHz

--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -30,8 +30,22 @@ function fill_sclks() {
 }
 
 function fill_sclk_offset() {
-  echo "  SCLK offset: ${1}"
-  SCLK_OFFSET="s ${1%*M[Hh]z}"
+  local offset_value
+
+  if [[ $1 =~ M[Hh]z ]]; then
+    [[ -z $SCLK_OFFSET_METHOD ]] && SCLK_OFFSET_METHOD="proper"
+    offset_value="$1"
+  else
+    # Legacy method for Linux < 6.14
+    # Modyfing [0] index is unsupported
+    [[ -z $SCLK_OFFSET_METHOD ]] && SCLK_OFFSET_METHOD="legacy"
+    [[ $1 != "1" ]] && return
+    offset_value="$2"
+  fi
+
+  echo "  SCLK offset: $offset_value"
+  SCLK_OFFSET="s ${offset_value%*M[Hh]z}"
+  [[ $SCLK_OFFSET_METHOD == "legacy" ]] && SCLK_OFFSET="s 1 ${offset_value%*M[Hh]z}"
 }
 
 function fill_mclks() {
@@ -190,6 +204,7 @@ function set_custom_states() {
     sleep 0.25
   fi
   for CSTATE in "${SCLK[@]}"; do
+    [[ -z $CSTATE ]] && continue
     echo "${CSTATE}" > "${SYS_PP_OD_CLK}"
   done
   if [ "${SCLK_OFFSET}" ]; then
@@ -276,9 +291,9 @@ function restore_states() {
 }
 
 function clear_vars() {
-    unset SCLK MCLK SCLK_OFFSET
-    unset VDDC_CURVE VDDGFX_OFFSET
-    unset sys_device sys_hwmons
+  unset SCLK MCLK SCLK_OFFSET SCLK_OFFSET_METHOD
+  unset VDDC_CURVE VDDGFX_OFFSET
+  unset sys_device sys_hwmons
 }
 
 check_ppfeaturemask

--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -30,11 +30,8 @@ function fill_sclks() {
 }
 
 function fill_sclk_offset() {
-  echo "  SCLK offset ${1}: ${2}"
-
-  # For now, modyfing the [0] index is unsupported on RDNA4
-  if [[ $1 == "0" ]]; then return; fi
-  SCLK[${1}]="s ${1} ${2%*M[Hh]z}"
+  echo "  SCLK offset: ${1}"
+  SCLK="s ${1%*M[Hh]z}"
 }
 
 function fill_mclks() {
@@ -100,23 +97,23 @@ function parse_states() {
       "OD_RANGE:")
         echo "  Value ranges:";;
       "SCLK: "*)
-        echo "    SCLK clock ${LINE##* }"
+        echo "    SCLK clock range: ${LINE#* }"
         MAX_SCLK=${LINE##* }
         MAX_SCLK=${MAX_SCLK%*M[Hh]z}
         ;;
       "SCLK_OFFSET:"*)
-        echo "    SCLK offset ${LINE##* }"
-        MAX_SCLK=${LINE##* }
-        MAX_SCLK=${MAX_SCLK%*M[Hh]z}
+        echo "    SCLK offset range: ${LINE#* }"
+        MAX_SCLK_OFFSET=${LINE##* }
+        MAX_SCLK_OFFSET=${MAX_SCLK%*M[Hh]z}
         ;;
       "MCLK: "*)
-        echo "    MCLK clock ${LINE##* }"
+        echo "    MCLK clock range: ${LINE#* }"
         MAX_MCLK=${LINE##* }
         MAX_MCLK=${MAX_MCLK%*M[Hh]z}
         ;;
       "VDDGFX_OFFSET: "*)
         echo "    VDDGFX offset range: ${LINE#*: }"
-        OFFSET_RANGE=${LINE#*: }
+        VOLTAGE_OFFSET_RANGE=${LINE#*: }
         ;;
       "VDDC: "*)
         echo "    VDDC voltage ${LINE##* }"
@@ -124,6 +121,9 @@ function parse_states() {
         MAX_VDDC=${MAX_VDDC%*mV}
         ;;
       [0-9]": "*)
+        $state_fill_func ${LINE%%:*} ${LINE#* }
+        ;;
+      [-0-9]*"M"[Hh]"z")
         $state_fill_func ${LINE%%:*} ${LINE#* }
         ;;
       [-0-9]*"mV")

--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -31,7 +31,7 @@ function fill_sclks() {
 
 function fill_sclk_offset() {
   echo "  SCLK offset: ${1}"
-  SCLK="s ${1%*M[Hh]z}"
+  SCLK_OFFSET="s ${1%*M[Hh]z}"
 }
 
 function fill_mclks() {
@@ -192,6 +192,9 @@ function set_custom_states() {
   for CSTATE in "${SCLK[@]}"; do
     echo "${CSTATE}" > "${SYS_PP_OD_CLK}"
   done
+  if [ "${SCLK_OFFSET}" ]; then
+    echo "${SCLK_OFFSET}" > "${SYS_PP_OD_CLK}"
+  fi
   for MSTATE in "${MCLK[@]}"; do
     OLD_MSTATE=${DETECTED_MCLK[$((${MSTATE:3:1}))]}
     if [ "${MSTATE}" != "${OLD_MSTATE}" ]; then
@@ -273,7 +276,7 @@ function restore_states() {
 }
 
 function clear_vars() {
-    unset SCLK MCLK
+    unset SCLK MCLK SCLK_OFFSET
     unset VDDC_CURVE VDDGFX_OFFSET
     unset sys_device sys_hwmons
 }


### PR DESCRIPTION
Support new RDNA4 interfaces introduced in:
https://lore.kernel.org/amd-gfx/20250311213833.870840-1-tomasz.pakula.oficjalny@gmail.com/T/#u

Waiting for patch to hit upstream.

<details>
<summary>Operation log</summary>

```
tomek@komputr ~/repos/amdgpu-clocks (rdna4-updates) $ cat /sys/class/drm/card1/device/pp_od_clk_voltage
OD_SCLK_OFFSET:
0Mhz
OD_MCLK:
0: 97Mhz
1: 1259MHz
OD_VDDGFX_OFFSET:
0mV
OD_RANGE:
SCLK_OFFSET:    -500Mhz       1000Mhz
MCLK:      97Mhz       1500Mhz
VDDGFX_OFFSET:    -200mv          0mv
tomek@komputr ~/repos/amdgpu-clocks (rdna4-updates) $ sudo ./amdgpu-clocks                        
WARNING: /sys/class/drm/card0/device/pp_od_clk_voltage does not exist, skipping!
Writen initial backup states to /tmp/amdgpu-custom-state.card1.initial
Detecting the state values at /sys/class/drm/card1/device/pp_od_clk_voltage:
  SCLK offset: 0Mhz
  MCLK state 0: 97Mhz
  MCLK state 1: 1259MHz
  VDD GFX Offset: 0mV
  Maximum clocks & voltages:
    SCLK offset range:    -500Mhz       1000Mhz
    MCLK clock range:      97Mhz       1500Mhz
    VDDGFX offset range:    -200mv          0mv
  Curent power cap: 304W
Verifying user state values at /etc/default/amdgpu-custom-state.card1:
  SCLK offset: -100Mhz
  VDD GFX Offset: -75mV
  Force power cap to 150W
Committing custom states to /sys/class/drm/card1/device/pp_od_clk_voltage:
  Done
tomek@komputr ~/repos/amdgpu-clocks (rdna4-updates) $ cat /sys/class/drm/card1/device/pp_od_clk_voltage
OD_SCLK_OFFSET:
-100Mhz
OD_MCLK:
0: 97Mhz
1: 1259MHz
OD_VDDGFX_OFFSET:
-75mV
OD_RANGE:
SCLK_OFFSET:    -500Mhz       1000Mhz
MCLK:      97Mhz       1500Mhz
VDDGFX_OFFSET:    -200mv          0mv
```

</details>