### PR TITLE
Zero RPM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ one can alternatively define the custom state using
 `<domain>:<bus>:<dev>.<function>` numbers. For example
 `/etc/default/amdgpu-custom-state.pci:0000:03:00.0`.
 
+### Polaris
 Here is an example how custom power state file may look like for Polaris cards:
 
 ```shell
@@ -62,8 +63,9 @@ FORCE_POWER_CAP: 90000000
 FORCE_PERF_LEVEL: manual
 ```
 
+### RDNA 1
 Here is an example how custom power state file may look like for Navi cards:
-```
+```shell
 # For Navi (and Radeon7) we can only set highest SCLK & MCLK, "state 1":
 OD_SCLK:
 1: 1550MHz
@@ -79,7 +81,9 @@ FORCE_POWER_CAP: 87000000
 FORCE_PERF_LEVEL: manual
 ```
 
-Here is an example how custom power state file may look like for RDNA2 cards:
+### RDNA 2/3
+**RDNA 2** introduced voltage offset instead of direct voltage curve modification.
+Here is an example how custom power state file may look like:
 ```
 OD_VDDGFX_OFFSET:
 -75mV
@@ -87,9 +91,10 @@ FORCE_PERF_LEVEL: manual
 FORCE_POWER_CAP: 99000000
 ```
 
-With RDNA4, `pp_od_clk_voltage` exposes two `SCLK` offsets but only `1`
+### RDNA 4
+With **RDNA 4**, `pp_od_clk_voltage` exposes two `SCLK` offsets but only `1`
 (max `SCLK` offset) can be adjusted. Example of custom power state file:
-```
+```shell
 OD_SCLK_OFFSET:
 1: 200Mhz
 OD_MCLK:
@@ -101,6 +106,24 @@ FORCE_POWER_CAP: 25000000
 FORCE_PERF_LEVEL: manual
 # compute
 FORCE_POWER_PROFILE: 5
+```
+
+## Zero RPM
+**RDNA 3** and up exposes Zero RPM fan mode settings in `gpu_od/fan_ctrl/fan_zero_rpm_*`.
+`amdgpu-clocks` can read, store and set these values. Custom values are stored
+alongside other settings in `/etc/default/amdgpu-custom-state.cardX`.
+
+Example of custom power state file for RDNA3+ with Zero RPM settings:
+```shell
+# exmaple settings
+OD_VDDGFX_OFFSET:
+-30mV
+FORCE_POWER_CAP: 12000000
+# Zero RPM settings
+FAN_ZERO_RPM_ENABLE:
+0
+FAN_ZERO_RPM_STOP_TEMPERATURE:
+62
 ```
 
 ### Installing and manually running the script

--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -65,7 +65,20 @@ function fill_vddgfx_offset() {
   VDDGFX_OFFSET="vo ${1%*mV}"
 }
 
+function fill_zero_rpm() {
+  if [ "$1" == "enable" ]; then
+    echo "  Zero RPM enable: $2"
+    ZERO_RPM_ENABLE="$2"
+  fi
+  if [ "$1" == "temperature" ]; then
+    echo "  Zero RPM temperature: $2"
+    ZERO_RPM_STOP_TEMP="$2"
+  fi
+}
+
 function parse_states() {
+  local zero_rpm_setting
+
   mapfile -t STATE_LINES < <(tr -d '\000' < "$1")
   for LNNO in "${!STATE_LINES[@]}"; do
     LINE="${STATE_LINES[$LNNO]}"
@@ -85,7 +98,7 @@ function parse_states() {
       "OD_VDDGFX_OFFSET:")
         offset_fill_func=fill_vddgfx_offset ;;
       "OD_RANGE:")
-        echo "  Maximum clocks & voltages:";;
+        echo "  Value ranges:";;
       "SCLK: "*)
         echo "    SCLK clock ${LINE##* }"
         MAX_SCLK=${LINE##* }
@@ -116,6 +129,9 @@ function parse_states() {
       [-0-9]*"mV")
         $offset_fill_func ${LINE%%:*} ${LINE#* }
         ;;
+      [0-9]*)
+        $state_fill_func ${zero_rpm_setting} ${LINE%%:*} ${LINE#* }
+        ;;
       "FORCE_SCLK: "[0-9]*)
         echo "  Force SCLK state to ${LINE#* }"
         FORCE_SCLK=${LINE#* }
@@ -137,6 +153,18 @@ function parse_states() {
         echo "  Force power profile to ${LINE#* }"
         FORCE_PROFILE=${LINE#* }
         ;;
+      "FAN_ZERO_RPM_ENABLE:")
+        state_fill_func=fill_zero_rpm
+        zero_rpm_setting="enable"
+        ;;
+      "FAN_ZERO_RPM_STOP_TEMPERATURE:")
+        state_fill_func=fill_zero_rpm
+        zero_rpm_setting="temperature"
+        ;;
+      "ZERO_RPM_ENABLE: "*)
+        echo "    Zero RPM enable range: ${LINE#*: }" ;;
+      "ZERO_RPM_STOP_TEMPERATURE: "*)
+        echo "    Zero RPM stop temperature range: ${LINE#*: }" ;;
       "#"*) ;;
       "") ;;
       *)
@@ -197,6 +225,14 @@ function set_custom_states() {
   if [ "${FORCE_POWER_CAP}" ]; then
     echo "${FORCE_POWER_CAP}" > "${PWR_CAP_FILE}"
   fi
+  if [ "${ZERO_RPM_ENABLE}" ]; then
+    echo "${ZERO_RPM_ENABLE}" > "${SYS_ZERO_RPM_ENABLE}"
+    echo "c" > "${SYS_ZERO_RPM_ENABLE}"
+  fi
+  if [ "${ZERO_RPM_STOP_TEMP}" ]; then
+    echo "${ZERO_RPM_STOP_TEMP}" > "${SYS_ZERO_RPM_STOP_TEMP}"
+    echo "c" > "${SYS_ZERO_RPM_STOP_TEMP}"
+  fi
 }
 
 function backup_states() {
@@ -207,6 +243,15 @@ function backup_states() {
     fi
     echo "FORCE_PERF_LEVEL: $(cat "${PWR_LEVEL}")" >> "${BACKUP_STATE_FILE}"
     echo "FORCE_POWER_CAP: $(cat "${PWR_CAP_FILE}")" >> "${BACKUP_STATE_FILE}"
+
+    # Zero RPM
+    if [ -r  "${SYS_ZERO_RPM_ENABLE}" ]; then
+      cat "${SYS_ZERO_RPM_ENABLE}" >> "${BACKUP_STATE_FILE}"
+    fi
+    if [ -r  "${SYS_ZERO_RPM_STOP_TEMP}" ]; then
+      cat "${SYS_ZERO_RPM_STOP_TEMP}" >> "${BACKUP_STATE_FILE}"
+    fi
+
     echo "Writen initial backup states to ${BACKUP_STATE_FILE}"
   else
     echo "Won't write initial state to ${BACKUP_STATE_FILE}, it already exists."
@@ -256,6 +301,8 @@ for USER_STATE_FILE in ${USER_STATES_PATH}*.+(card?|card??|pci:????:??:??.?); do
   SYS_DPM_SCLK=${sys_device}/pp_dpm_sclk
   SYS_DPM_MCLK=${sys_device}/pp_dpm_mclk
   PWR_CAP_FILE=${sys_hwmons[0]}/power1_cap
+  SYS_ZERO_RPM_ENABLE=${sys_device}/gpu_od/fan_ctrl/fan_zero_rpm_enable
+  SYS_ZERO_RPM_STOP_TEMP=${sys_device}/gpu_od/fan_ctrl/fan_zero_rpm_stop_temperature
 
   if [ -f "${SYS_PP_OD_CLK}" ]; then
     if [ "${RESTORE}" == "true" ]; then
@@ -263,10 +310,26 @@ for USER_STATE_FILE in ${USER_STATES_PATH}*.+(card?|card??|pci:????:??:??.?); do
     else
       backup_states
     fi
+    echo ""
     echo "Detecting the state values at ${SYS_PP_OD_CLK}:"
     parse_states "${SYS_PP_OD_CLK}"
+
+    if [ -r "${SYS_ZERO_RPM_ENABLE}" ]; then
+      echo ""
+      echo "Detecting the state values at ${SYS_ZERO_RPM_ENABLE}:"
+      parse_states "${SYS_ZERO_RPM_ENABLE}"
+    fi
+    if [ -r "${SYS_ZERO_RPM_STOP_TEMP}" ]; then
+      echo ""
+      echo "Detecting the state values at ${SYS_ZERO_RPM_STOP_TEMP}:"
+      parse_states "${SYS_ZERO_RPM_STOP_TEMP}"
+    fi
+
+    echo ""
     echo "Verifying user state values at ${USER_STATE_FILE}:"
     parse_states "${USER_STATE_FILE}"
+
+    echo ""
     echo "Committing custom states to ${SYS_PP_OD_CLK}:"
     set_custom_states
     echo "  Done"


### PR DESCRIPTION
Zero RPM mode settings were introduced a few months back to RDNA3. RDNA4 patches already sent as it didn't support it on release.

This allows users to control the Zero RPM mode and it's stop temperature.

<details>
<summary>Operation log</summary>

```
tomek@komputr ~/repos/amdgpu-clocks (zero-rpm*) $ sudo ./amdgpu-clocks        
WARNING: /sys/class/drm/card0/device/pp_od_clk_voltage does not exist, skipping!
Writen initial backup states to /tmp/amdgpu-custom-state.card1.initial

Detecting the state values at /sys/class/drm/card1/device/pp_od_clk_voltage:
  SCLK offset: 0Mhz
  MCLK state 0: 97Mhz
  MCLK state 1: 1259MHz
  VDD GFX Offset: 0mV
  Value ranges:
    SCLK offset range:    -500Mhz       1000Mhz
    MCLK clock range:      97Mhz       1500Mhz
    VDDGFX offset range:    -200mv          0mv
  Curent power cap: 304W

Detecting the state values at /sys/class/drm/card1/device/gpu_od/fan_ctrl/fan_zero_rpm_enable:
  Zero RPM enable: 1
  Value ranges:
    Zero RPM enable range: 0 1

Detecting the state values at /sys/class/drm/card1/device/gpu_od/fan_ctrl/fan_zero_rpm_stop_temperature:
  Zero RPM temperature: 50
  Value ranges:
    Zero RPM stop temperature range: 50 110

Verifying user state values at /etc/default/amdgpu-custom-state.card1:
  SCLK offset: 100MHz
  VDD GFX Offset: -75mV
  Force power cap to 250W
  Zero RPM enable: 0
  Zero RPM temperature: 65

Committing custom states to /sys/class/drm/card1/device/pp_od_clk_voltage:
  Done
tomek@komputr ~/repos/amdgpu-clocks (zero-rpm*) $ cat /sys/class/drm/card1/device/gpu_od/fan_ctrl/fan_zero_rpm_enable 
FAN_ZERO_RPM_ENABLE:
0
OD_RANGE:
ZERO_RPM_ENABLE: 0 1
tomek@komputr ~/repos/amdgpu-clocks (zero-rpm*) $ cat /sys/class/drm/card1/device/gpu_od/fan_ctrl/fan_zero_rpm_stop_temperature 
FAN_ZERO_RPM_STOP_TEMPERATURE:
65
OD_RANGE:
ZERO_RPM_STOP_TEMPERATURE: 50 110
```

</details>