### PR TITLE
Zero rpm warning and fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ FORCE_POWER_PROFILE: 5
 `amdgpu-clocks` can read, store and set these values. Custom values are stored
 alongside other settings in `/etc/default/amdgpu-custom-state.cardX`.
 
+*Warning: Zero RPM fan mode is only available on Linux 6.13 or newer!*
+
 Example of custom power state file for RDNA3+ with Zero RPM settings:
 ```shell
 # exmaple settings

--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -225,13 +225,17 @@ function set_custom_states() {
   if [ "${FORCE_POWER_CAP}" ]; then
     echo "${FORCE_POWER_CAP}" > "${PWR_CAP_FILE}"
   fi
-  if [ "${ZERO_RPM_ENABLE}" ]; then
+  if [ -f "${SYS_ZERO_RPM_ENABLE}" ] && [ "${ZERO_RPM_ENABLE}" ]; then
     echo "${ZERO_RPM_ENABLE}" > "${SYS_ZERO_RPM_ENABLE}"
     echo "c" > "${SYS_ZERO_RPM_ENABLE}"
+  else
+	echo "Skipping ZERO_RPM_ENABLE: make sure to have Linux 6.13 or newer."
   fi
-  if [ "${ZERO_RPM_STOP_TEMP}" ]; then
+  if [ -f "${SYS_ZERO_RPM_STOP_TEMP}" ] && [ "${ZERO_RPM_STOP_TEMP}" ]; then
     echo "${ZERO_RPM_STOP_TEMP}" > "${SYS_ZERO_RPM_STOP_TEMP}"
     echo "c" > "${SYS_ZERO_RPM_STOP_TEMP}"
+  else
+	echo "Skipping FAN_ZERO_RPM_STOP_TEMPERATURE: make sure to have Linux 6.13 or newer."
   fi
 }
 

--- a/amdgpu-clocks
+++ b/amdgpu-clocks
@@ -177,7 +177,7 @@ function parse_states() {
     DETECTED_MCLK=("${MCLK[@]}")
     DETECTED_VDDC_CURVE=("${VDDC_CURVE[@]}")
     POWER_LIMIT=$(cat "$PWR_CAP_FILE")
-    echo "  Curent power cap: ${POWER_LIMIT%*000000}W"
+    echo "  Current power cap: ${POWER_LIMIT%*000000}W"
   fi
 }
 
@@ -252,7 +252,7 @@ function backup_states() {
       cat "${SYS_ZERO_RPM_STOP_TEMP}" >> "${BACKUP_STATE_FILE}"
     fi
 
-    echo "Writen initial backup states to ${BACKUP_STATE_FILE}"
+    echo "Written initial backup states to ${BACKUP_STATE_FILE}"
   else
     echo "Won't write initial state to ${BACKUP_STATE_FILE}, it already exists."
   fi


### PR DESCRIPTION
Added warning for zero rpm settings which is only available on Linux 6.13 or newer. If the fan control settings/files are not found, it will skip applying the settings and give a helpful warning instead of a file permission denied error.

Also fixed minor typos.

<details>
<summary>Operation log</summary>
Won't write initial state to /tmp/amdgpu-custom-state.card1.initial, it already exists.

Detecting the state values at /sys/class/drm/card1/device/pp_od_clk_voltage:
  SCLK state 0: 500Mhz
  SCLK state 1: 2500Mhz
  MCLK state 0: 97Mhz
  MCLK state 1: 1125MHz
  VDD GFX Offset: -150mV
  Value ranges:
    SCLK clock 5000Mhz
    MCLK clock 1500Mhz
    VDDGFX offset range:    -450mv          0mv
  Current power cap: 240W

Verifying user state values at /etc/default/amdgpu-custom-state.card1:
  SCLK state 1: 2500MHz
  VDD GFX Offset: -150mV
  Force power cap to 240W
  Zero RPM enable: 0
  Zero RPM temperature: 62

Committing custom states to /sys/class/drm/card1/device/pp_od_clk_voltage:
Skipping ZERO_RPM_ENABLE: make sure to have Linux 6.13 or newer.
Skipping FAN_ZERO_RPM_STOP_TEMPERATURE: make sure to have Linux 6.13 or newer.
  Done
</details>