### PR TITLE
Add info about Zero RPM stop temparature

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,11 @@ FORCE_POWER_PROFILE: 5
 `amdgpu-clocks` can read, store and set these values. Custom values are stored
 alongside other settings in `/etc/default/amdgpu-custom-state.cardX`.
 
-*Warning: Zero RPM fan mode is only available on Linux 6.13 or newer!*
+> [!IMPORTANT]
+> Warning: Zero RPM fan mode settings is only available on Linux `6.13` or newer!
+
+> [!NOTE]
+> Zero RPM stop temperature setting is only available for RDNA 3
 
 Example of custom power state file for RDNA3+ with Zero RPM settings:
 ```shell
@@ -124,6 +128,7 @@ FORCE_POWER_CAP: 12000000
 # Zero RPM settings
 FAN_ZERO_RPM_ENABLE:
 0
+# Only on RDNA 3
 FAN_ZERO_RPM_STOP_TEMPERATURE:
 62
 ```


### PR DESCRIPTION
Zero RPM stop temperature setting is only available on RDNA 3. With RDNA 4 and up, it won't be exposed in amdgpu to align functionality with windows (https://lore.kernel.org/amd-gfx/20250315201558.339913-1-tomasz.pakula.oficjalny@gmail.com/T/#mef2b1dad7f0ec234aa27534656d6d57cfcf8b768)

Update readme to inform users of this fact.